### PR TITLE
fix: update only modified

### DIFF
--- a/app/Http/Controllers/EpisodesController.php
+++ b/app/Http/Controllers/EpisodesController.php
@@ -6,6 +6,7 @@ use App\Models\Episode;
 use App\Models\Season;
 use App\Repositories\EpisodesRepository;
 use App\Repositories\SeasonsRepository;
+use DateTime;
 use Illuminate\Http\Request;
 
 class EpisodesController extends Controller
@@ -21,17 +22,26 @@ class EpisodesController extends Controller
     public function store(Request $request, EpisodesRepository $repository, Season $season)
     {
         $watchedEpisodes = $request->episodes;
-        if ($watchedEpisodes == null) {
-            $season->episodes->each(function (Episode $episode) use ($watchedEpisodes) {
-                $episode->watched = false;
-            });
-        } else {
-            $season->episodes->each(function (Episode $episode) use ($watchedEpisodes) {
-                $episode->watched = in_array($episode->id, $watchedEpisodes);
-            });
-        }
+        $episodes = $season->episodes;
 
-        $season->push();
+        # TODO: Alterar somente aqueles que foram modificados.
+        # Todos os episódios estão sendo alterados, o que faz com que seu updated_at seja atualizado.
+
+        $episodes->each(function ($episode) use ($watchedEpisodes) {
+            if (!$episode->watched && in_array($episode->id, $watchedEpisodes)) {
+                echo "$episode->id True";
+                $episode->watched = true;
+                $episode->updated_at = new DateTime('now', new \DateTimeZone('America/Sao_Paulo'));
+
+            } elseif ($episode->watched && !in_array($episode->id, $watchedEpisodes)) {
+                echo "$episode->id False";
+                $episode->watched = false;
+                $episode->updated_at = new DateTime('now', new \DateTimeZone('America/Sao_Paulo'));
+            }
+        });
+
+        $episodes = $episodes->toArray();
+        $repository->create($episodes);
 
         return to_route('episodes.index', $season->id);
     }

--- a/app/Repositories/Eloquent/EloquentEpisodesRepository.php
+++ b/app/Repositories/Eloquent/EloquentEpisodesRepository.php
@@ -10,7 +10,9 @@ class EloquentEpisodesRepository implements EpisodesRepository
 {
     public function create(array $episodes)
     {
-        return Episode::updateOrInsert($episodes);
+        return Episode::upsert($episodes,
+            ['id'],
+            ['watched', 'updated_at']);
     }
 
     public function find(int $id): ? Episode
@@ -27,13 +29,4 @@ class EloquentEpisodesRepository implements EpisodesRepository
     {
         return Episode::destroy($id);
     }
-
-    public function update(Episode $episode)
-    {
-        $episode->update();
-    }
-
-
-
-
 }

--- a/app/Repositories/EpisodesRepository.php
+++ b/app/Repositories/EpisodesRepository.php
@@ -12,6 +12,5 @@ interface EpisodesRepository
     public function find(int $id): ? Episode;
     public function findAll(): Collection;
     public function delete(int $id): int;
-    public function update(Episode $episode);
 }
 


### PR DESCRIPTION
### Alterando a lógica do update dos episódios.

#### O que é evitado com esta modificação: 

- Falsa informação de alteração nos episódios ( O campo "updated_at" de todos os episódios de uma série era atualizado caso alteracemos somente um episódio )

#### Alterações futuras:

- Verificar melhores formas de resolver esse problema
- O update pode ficar na função store do nosso controller? 
- É padrão de código no PHP usarmos a função create de um repository para também atualizarmos algum episódio que ja exista? (Trouxe isso de outra linguagem)